### PR TITLE
fix(API): Use query parameters instead of request headers

### DIFF
--- a/frontend/pages/DevPage.tsx
+++ b/frontend/pages/DevPage.tsx
@@ -10,7 +10,7 @@ const DevPage: NextPage = () => {
     const getEventsByYear = useCallback(() => {
         axios
             .get(
-                `http://localhost:8000/api/events/?year=${year}`, //TODO: add proxy instead of full api url
+                `http://openf1.ncik-dv.com/api/events/?year=${year}`, //TODO: add proxy instead of full api url
             )
             .then(function (response: any) {
                 setEvents(response.data);

--- a/frontend/pages/DevPage.tsx
+++ b/frontend/pages/DevPage.tsx
@@ -10,7 +10,7 @@ const DevPage: NextPage = () => {
     const getEventsByYear = useCallback(() => {
         axios
             .get(
-                "https://fastf1-webviewer-api.herokuapp.com/api/events/", //TODO: add proxy instead of full api url
+                "https://openf1-api.herokuapp.com/api/events/", //TODO: add proxy instead of full api url
                 {
                     headers: {
                         year: year,

--- a/frontend/pages/DevPage.tsx
+++ b/frontend/pages/DevPage.tsx
@@ -10,7 +10,7 @@ const DevPage: NextPage = () => {
     const getEventsByYear = useCallback(() => {
         axios
             .get(
-                `http://openf1.ncik-dv.com/api/events/?year=${year}`, //TODO: add proxy instead of full api url
+                `http://openf1-api.herokuapp.com/api/events/?year=${year}`, //TODO: add proxy instead of full api url
             )
             .then(function (response: any) {
                 setEvents(response.data);

--- a/frontend/pages/DevPage.tsx
+++ b/frontend/pages/DevPage.tsx
@@ -10,7 +10,7 @@ const DevPage: NextPage = () => {
     const getEventsByYear = useCallback(() => {
         axios
             .get(
-                `http://openf1-api.herokuapp.com/api/events/?year=${year}`, //TODO: add proxy instead of full api url
+                `/api/events/?year=${year}`,
             )
             .then(function (response: any) {
                 setEvents(response.data);

--- a/frontend/pages/DevPage.tsx
+++ b/frontend/pages/DevPage.tsx
@@ -10,12 +10,7 @@ const DevPage: NextPage = () => {
     const getEventsByYear = useCallback(() => {
         axios
             .get(
-                "https://openf1-api.herokuapp.com/api/events/", //TODO: add proxy instead of full api url
-                {
-                    headers: {
-                        year: year,
-                    },
-                }
+                `http://localhost:8000/api/events/?year=${year}`, //TODO: add proxy instead of full api url
             )
             .then(function (response: any) {
                 setEvents(response.data);

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,5 +1,8 @@
 import "../styles/globals.css";
 import type { AppProps } from "next/app";
+import axios from "axios";
+
+axios.defaults.baseURL = "https://openf1-api.herokuapp.com";
 
 function MyApp({ Component, pageProps }: AppProps) {
   return <Component {...pageProps} />;

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -21,7 +21,7 @@ const Home: NextPage = () => {
 
         <p className={styles.description}>
           Check our progress <a href='https://github.com/users/ndv99/projects/1'>here</a><br />
-          View the source code <a href='https://github.com/ndv99/FastF1_WebViewer'>here</a> <br/>
+          View the source code <a href='https://github.com/ndv99/OpenF1'>here</a> <br/>
           View the dev page <Link href="/DevPage"><a>here</a></Link>
         </p>
       </main>

--- a/server/settings.py
+++ b/server/settings.py
@@ -136,7 +136,5 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 CORS_ALLOW_ALL_ORIGINS = True
 
 CORS_ALLOW_METHODS = [
-'GET',
+    'GET',
 ]
-
-CORS_ALLOW_HEADERS = ['year']


### PR DESCRIPTION
# This PR is for API changes

## Changes

- Update index and dev page request URLs to new site name (https://openf1-api.herokuapp.com)
- Modify existing views to use query parameters instead of request headers
- Add strict typing in views for requests and parameters
- Set base URL for axios requests to production API deployment (https://openf1-api.herokuapp.com)

## Issues resolved

-Fixes #39
-Fixes #34