### PR TITLE
feat(API): Get all available years with telemetry

### DIFF
--- a/frontend/pages/components/YearSelector.tsx
+++ b/frontend/pages/components/YearSelector.tsx
@@ -1,33 +1,47 @@
 
 import { Select } from "@canonical/react-components";
+import axios from "axios";
+import { useEffect, useState } from "react";
 
 
 const YearSelector = (props: any) => {
     const setYear = props.setYear;
+    const [years, setYears] = useState([{value:0, label: "Select a year", disabled: true}]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        if (loading) {
+            axios.get("/api/years/")
+            .then((res) => {
+                const tempYears = years;
+
+                for ( var year in res.data["years"] ) {
+                    tempYears.push({ value: parseInt(res.data["years"][year]), label: res.data["years"][year] , disabled:false });
+                };
+
+                setYears(tempYears);
+                setLoading(false);
+            })
+            .catch((err) => {
+                console.error("Unable to get available years. Error: ",  err);
+            });
+        }
+    }, [years, loading]);
     
     const handleChange =(event: any)=>{
         setYear(event.target[event.target.selectedIndex].value);
     };
 
-    const createYearList2018toCurrentYear = () => {
-
-        const list = [{value:0, label: "Select a year", disabled: true}];
-
-        let year = parseInt(new Date().getFullYear().toString().substring(-2));
-
-        do {
-            list.push({ value: year, label: year.toString() , disabled:false});
-            year--;
-        } while (year >= 2018);
-
-        return list;
-    };
-
-
     return (
-        <div id="year-selector-wrapper">
-            <Select defaultValue={0} onChange={handleChange} options={createYearList2018toCurrentYear()} />
-        </div>
+        <>
+            {(loading ? (
+                <p>Loading...</p>
+            ) : (
+                <div id="year-selector-wrapper">
+                    <Select defaultValue={0} onChange={handleChange} options={years} />
+                </div>
+            ))}
+        </>
     );
 };
 

--- a/server/urls.py
+++ b/server/urls.py
@@ -21,6 +21,7 @@ from webviewer import views
 router = routers.DefaultRouter()
 router.register(r'events', views.Events, 'events')
 router.register(r'raceLapChart', views.RaceLapChart, 'raceLapChart')
+router.register(r'years', views.Years, 'years')
 
 urlpatterns = [
     path('admin/', admin.site.urls),

--- a/webviewer/views.py
+++ b/webviewer/views.py
@@ -7,6 +7,8 @@ import json
 import fastf1
 import os
 
+years = list(range(2018, 2023)) # range() is not inclusive for the max value
+
 def assemble_url(params, url):
     for p in params:
         if url[-1] != "?":
@@ -29,11 +31,11 @@ def get_year_from_request(headers):
         error =  Response(res, status.HTTP_400_BAD_REQUEST)
         return error, year
 
-    if year < 2018:
+    if year < min(years):
         res = {'errorMessage': "Telemetry is only available from 2018 onwards."}
         error =  Response(res, status.HTTP_400_BAD_REQUEST)
     
-    if year > 2022:
+    if year > max(years):
         res = {'errorMessage': "It's still 2022, we can't predict the future!"}
         error =  Response(res, status.HTTP_400_BAD_REQUEST)
     
@@ -63,6 +65,13 @@ def enable_cache():
     fastf1.Cache.enable_cache('server/fastf1_cache')
 
 # Create your views here.
+
+class Years(viewsets.ViewSet):
+
+    def list(self, request, *args, **kwargs):
+        res = { "years": years }
+        return Response(res, status.HTTP_200_OK)
+
 
 class Events(viewsets.ViewSet):
 


### PR DESCRIPTION
# This PR is for frontend/API

## Changes

List the changes you made in this PR.
- Added API endpoint to get all available years with telemetry data
- Updated YearSelect component to use this endpoint instead of generating years
  
## QA

Steps for QA
1. **Clone this branch locally** and set the axios base url to "http://localhost:8000" in [_app.tsx](https://github.com/ndv99/OpenF1/blob/main/frontend/pages/_app.tsx#L5)
2. Run the API and the frontend
3. In your browser, go to http://localhost:3000/DevPage
4. Ensure the year selector has been filled out with values
5. Ensure an API call has been made to get years by checking the API log for `"GET /api/years/ HTTP/1.1" 200 36`

## Issues resolved

Fixes #1 