### PR TITLE
chore(frontend): Use different API URL for production and development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,6 +133,7 @@ celerybeat.pid
 
 # Environments
 .env
+!frontend/.env
 .venv
 env/
 venv/

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_QUERY_URL = https://openf1-api.herokuapp.com

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,7 @@
+# If you want to use prod for API calls in development,
+# create a file in this directory called .env.local and
+# add the following line:
+#
+# NEXT_PUBLIC_QUERY_URL = https://openf1-api.herokuapp.com
+
+NEXT_PUBLIC_QUERY_URL = http://localhost:8000

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -2,7 +2,7 @@ import "../styles/globals.css";
 import type { AppProps } from "next/app";
 import axios from "axios";
 
-axios.defaults.baseURL = "https://openf1-api.herokuapp.com";
+axios.defaults.baseURL = process.env.NEXT_PUBLIC_QUERY_URL;
 
 function MyApp({ Component, pageProps }: AppProps) {
   return <Component {...pageProps} />;


### PR DESCRIPTION
# This PR is for frontend/maintenance changes

## Changes

- Add a `.env` file in `frontend` to define the default query URL (https://openf1-api.herokuapp.com)
- Add a `.env.development` file in `frontend` to use a locally hosted API
  
## QA

### Frontend

If there are no errors, Vercel will comment on this PR with a preview link.

### QA Steps

Steps for QA
1. Open the Vercel preview
2. Navigate to /DevPage
3. Open the browser dev tools and go to the "Network" tab
4. Select a year in the dropdown
5. Ensure a request is made that looks like `?year=<year>` and ensure the endpoint for this is prod (https://openf1-api.nick-dv.com)
6. Run the API and frontend locally, then repeat steps 2 to 4
7. Ensure  a request is made that looks like `?year=<year>` and ensure the endpoint for this is dev (http://localhost:8000)