### PR TITLE
feat(API): Add endpoint to get sessions in an event

### DIFF
--- a/server/urls.py
+++ b/server/urls.py
@@ -22,6 +22,7 @@ router = routers.DefaultRouter()
 router.register(r'events', views.Events, 'events')
 router.register(r'raceLapChart', views.RaceLapChart, 'raceLapChart')
 router.register(r'years', views.Years, 'years')
+router.register(r'eventSessions', views.EventSessions, 'eventSessions')
 
 urlpatterns = [
     path('admin/', admin.site.urls),

--- a/webviewer/views.py
+++ b/webviewer/views.py
@@ -90,7 +90,7 @@ class Events(viewsets.ViewSet):
             return error
 
         enable_cache()
-        schedule = fastf1.get_event_schedule(year)
+        schedule = fastf1.get_event_schedule(year, include_testing=False)
         event_names = schedule.EventName.values.tolist()
         res = {"events": event_names}
         return Response(res, status.HTTP_200_OK)
@@ -112,7 +112,7 @@ class EventSessions(viewsets.ViewSet):
             return event_error
 
         enable_cache()
-        schedule = fastf1.get_event_schedule(year)
+        schedule = fastf1.get_event_schedule(year, include_testing=False)
         event = schedule.get_event_by_name(event_name)
         sessions = []
         for i in range(1,6):

--- a/webviewer/views.py
+++ b/webviewer/views.py
@@ -116,7 +116,7 @@ class EventSessions(viewsets.ViewSet):
         event = schedule.get_event_by_name(event_name)
         sessions = []
         for i in range(1,6):
-            sessions.append(event.get_session_name(i))
+            sessions.append({"label": event.get_session_name(i), "value": i})
         
         res = { "sessions": sessions }
         return Response(res, status.HTTP_200_OK)

--- a/webviewer/views.py
+++ b/webviewer/views.py
@@ -95,11 +95,35 @@ class Events(viewsets.ViewSet):
         res = {"events": event_names}
         return Response(res, status.HTTP_200_OK)
 
+class EventSessions(viewsets.ViewSet):
+
+    def list(self, request: Request, *args, **kwargs):
+
+        params = request.query_params
+
+        year_error, year = get_year_from_request(params)
+
+        if year_error:
+            return year_error
+
+        event_error, event_name = get_event_from_request(params)
+
+        if event_error:
+            return event_error
+
+        enable_cache()
+        schedule = fastf1.get_event_schedule(year)
+        event = schedule.get_event_by_name(event_name)
+        sessions = []
+        for i in range(1,6):
+            sessions.append(event.get_session_name(i))
+        
+        res = { "sessions": sessions }
+        return Response(res, status.HTTP_200_OK)
 
 class RaceLapChart(viewsets.ViewSet):
     def list(self, request: Request, *args, **kwargs):
 
-        headers = request.query_params
         params = request.query_params
 
         year_error, year = get_year_from_request(params)


### PR DESCRIPTION
# This PR is for API changes

## Changes

- Created an API endpoint to get sessions that occurred within an event
  
## QA

### API

If there are no errors, you should be able to get a Heroku preview deployment in the message reading "This branch was successfully deployed".

### QA Steps

1. Once the heroku preview deployment is ready, open Postman (or other API testing software), and make a query to https://openf1-api-geteventsess-oxgouz.herokuapp.com/api/eventSessions?year=2022&event=Italy
2. Ensure that the response contains all sessions that occurred in Italy 2022
3. Change the year and event a few times and ensure that the correct data is returned (e.g. try Brazil 2021 and ensure that it has Sprint Qualifying and no Practice 3)

Example response:
```json
{
    "sessions": [
        {
            "label": "Practice 1",
            "value": 1
        },
        {
            "label": "Practice 2",
            "value": 2
        },
        {
            "label": "Practice 3",
            "value": 3
        },
        {
            "label": "Qualifying",
            "value": 4
        },
        {
            "label": "Race",
            "value": 5
        }
    ]
}
```

## Related issues

Linked to #3 