### PR TITLE
feat(API): Add endpoint to get drivers in a session

### DIFF
--- a/server/urls.py
+++ b/server/urls.py
@@ -22,6 +22,7 @@ router = routers.DefaultRouter()
 router.register(r'events', views.Events, 'events')
 router.register(r'raceLapChart', views.RaceLapChart, 'raceLapChart')
 router.register(r'years', views.Years, 'years')
+router.register(r'sessionDrivers', views.SessionDrivers, 'sessionDrivers')
 
 urlpatterns = [
     path('admin/', admin.site.urls),


### PR DESCRIPTION
# This PR is for API changes

## Changes

List the changes you made in this PR.
- Added an API endpoint to get a list of drivers in a session
  
## QA

### API

If there are no errors, you should be able to get a Heroku preview deployment in the message reading "This branch was successfully deployed".

### QA Steps

1. Once the heroku preview deployment is ready, open Postman (or other API testing software), and make a query to <preview url>/api/sessionDrivers?year=2022&event=Italy&session=1
2. Ensure that the response contains all drivers who participated in Practice 1 in Italy 2022
3. Change the year, event, and session a few times and ensure that the correct data is returned.

Example response:
```json
{
    "drivers": [
        {
            "name": "Max Verstappen",
            "abbreviation": "VER"
        },
        {
            "name": "Carlos Sainz",
            "abbreviation": "SAI"
        },
        ...
    ]
}
```

## Related issues

Linked to #4 